### PR TITLE
Improve mind-map overlap handling

### DIFF
--- a/Mind-Map.html
+++ b/Mind-Map.html
@@ -159,24 +159,37 @@ if(cytoscape.layoutUtilities){
 }
 
 
+ /* place new nodes near their parent */
+ function placeNearParent(id,parent){
+   const p=cy.getElementById(parent);
+   const n=cy.getElementById(id);
+   if(!p||!n) return;
+   const pos=p.position();
+   const ang=Math.random()*2*Math.PI;
+   n.position({x:pos.x+80*Math.cos(ang),y:pos.y+80*Math.sin(ang)});
+ }
+
  /* tap‑to‑extend */
  cy.on('tap','node',evt=>{
    const n=evt.target;
-   const eg=`{"nodes":[{"id":"newId","text":"New","parent":"${n.id()}"}],
-"edges":[{"source":"${n.id()}","target":"newId","label":"rel","direction":"out"}]}`;
+   const eg=`{"nodes":[{"id":"newId","text":"New","parent":"${n.id()}"}],"edges":[{"source":"${n.id()}","target":"newId","label":"rel","direction":"out"}]}`;
    const raw=prompt('Add JSON to expand this node:\n'+eg);
    if(!raw) return;
    try{
      const extra=JSON.parse(raw);
      cy.add(jsonToEls(extra));
-     layout(true);
+     (extra.nodes||[]).forEach(nn=>placeNearParent(nn.id,nn.parent));
+     if(lu) lu.run('prevent-overlap');
+     resolveCollisions(8);
+     adjustLabels();
+     cy.animate({fit:{eles:cy,padding:40}},{duration:400});
    }catch{alert('Bad JSON');}
  });
 
  /* after dragging, push overlaps away */
 cy.on('dragfree','node',()=>{
   if(lu) lu.run('prevent-overlap');
-  resolveCollisions();
+  resolveCollisions(8);
   adjustLabels();
 });
 }
@@ -187,7 +200,7 @@ const unit=v=>{const l=Math.hypot(v.x,v.y)||1;return{x:v.x/l,y:v.y/l}};
 const push=(n,v,d)=>n.position({x:n.position('x')+v.x*d,y:n.position('y')+v.y*d});
 
 /* push nodes away from edges and edge labels */
-function resolveCollisions(iter=4){
+function resolveCollisions(iter=8){
   for(let k=0;k<iter;k++){
     let moved=false;
     cy.nodes().forEach(n=>{
@@ -225,6 +238,14 @@ function adjustLabels(){
         bb=ei.boundingBox({includeEdges:false,includeLabels:true,includeNodes:false});
       }
     });
+    cy.edges().forEach((e2)=>{
+      if(e2.id()===ei.id()) return;
+      if(rectsOverlap(bb,e2.boundingBox())){
+        const sign=e2.midpoint().y>ei.midpoint().y?-1:1;
+        ei.style('text-margin-y',parseFloat(ei.style('text-margin-y'))+sign*14);
+        bb=ei.boundingBox({includeEdges:false,includeLabels:true,includeNodes:false});
+      }
+    });
     for(let j=i+1;j<edges.length;j++){
       const ej=edges[j];
       const bj=ej.boundingBox({includeEdges:false,includeLabels:true,includeNodes:false});
@@ -243,7 +264,7 @@ function layout(full){
     edgeElasticity:0.25,nodeDimensionsIncludeLabels:true
   }).run();
   if(lu) lu.run('prevent-overlap');
-  resolveCollisions();
+  resolveCollisions(8);
   adjustLabels();
   if(full) cy.animate({fit:{eles:cy,padding:40}}, {duration:400});
 }


### PR DESCRIPTION
## Summary
- keep new nodes near their parents without re-running the whole layout
- resolve collisions using more iterations
- shift edge labels away from overlapping edges

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686443126b1883299d306079dc0ade6c