### PR TITLE
fix: add react-bootstrap-icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "firebase": "^11.10.0",
+        "react-bootstrap-icons": "^1.11.6",
         "react-helmet": "^6.1.0"
       }
     },
@@ -955,6 +956,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-bootstrap-icons": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-icons/-/react-bootstrap-icons-1.11.6.tgz",
+      "integrity": "sha512-ycXiyeSyzbS1C4+MlPTYe0riB+UlZ7LV7YZQYqlERV2cxDiKtntI0huHmP/3VVvzPt4tGxqK0K+Y6g7We3U6tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.6"
       }
     },
     "node_modules/react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "firebase": "^11.10.0",
+    "react-bootstrap-icons": "^1.11.6",
     "react-helmet": "^6.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add react-bootstrap-icons to project dependencies

## Testing
- `npm install react-bootstrap-icons --save`
- `git push origin main` *(fails: "'origin' does not appear to be a git repository")*

------
https://chatgpt.com/codex/tasks/task_e_686482a148208329bf562d80c2428956